### PR TITLE
Resolve issue where SmartThings supplies empty JSON

### DIFF
--- a/index.js
+++ b/index.js
@@ -300,6 +300,8 @@ async function callJsonApi(url, token, payload) {
                 console.log(`received api response; payload=${JSON.stringify(body)}`);
                 if (body.length > 0) {
                     resolve(JSON.parse(body));
+                } else {
+                    resolve(JSON.parse("{}"));
                 }
             });
         });

--- a/index.js
+++ b/index.js
@@ -298,7 +298,9 @@ async function callJsonApi(url, token, payload) {
             res.on("end", () => {
                 body = body.join();
                 console.log(`received api response; payload=${JSON.stringify(body)}`);
-                resolve(JSON.parse(body));
+                if (body.length > 0) {
+                    resolve(JSON.parse(body));
+                }
             });
         });
         req.on("error", res => {


### PR DESCRIPTION
Sometimes SmartThings will return a empty JSON, causing the parse to fail. This checks that before parsing,